### PR TITLE
Introduce Mint conversions to and from all types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ std = []
 
 [dependencies]
 bytemuck = { version = "1", optional = true }
-mint = "0.5.5"
+mint = { version = "0.5.5", optional = true }
 
 [dev-dependencies]
 bytemuck = { version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ std = []
 
 [dependencies]
 bytemuck = { version = "1", optional = true }
+mint = "0.5.5"
 
 [dev-dependencies]
 bytemuck = { version = "1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 macro_rules! define_vector {
-    ($name:ident, $mint_type:ty, $align:literal, $ty:ty, $count:literal<- $doc:literal) => {
+    ($name:ident, $mint_type:ident, $align:literal, $ty:ty, $count:literal<- $doc:literal) => {
         #[doc = $doc]
         #[repr(C, align($align))]
         #[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
@@ -88,9 +88,9 @@ macro_rules! define_vector {
         }
 
         #[cfg(feature = "mint")]
-        impl From<$mint_type> for $name {
+        impl From<mint::$mint_type<$ty>> for $name {
             #[inline(always)]
-            fn from(other: $mint_type) -> Self {
+            fn from(other: mint::$mint_type<$ty>) -> Self {
                 // Mint's types do not implement From for arrays, only Into.
                 let inner: [$ty; $count] = other.into();
 
@@ -108,7 +108,7 @@ macro_rules! define_vector {
         }
 
         #[cfg(feature = "mint")]
-        impl From<$name> for $mint_type {
+        impl From<$name> for mint::$mint_type<$ty> {
             #[inline(always)]
             fn from(other: $name) -> Self {
                 other.inner.into()
@@ -124,21 +124,21 @@ macro_rules! define_vector {
     };
 }
 
-define_vector!(Vec2, mint::Vector2<f32>, 8, f32, 2 <- "Vector of 2 f32s. Alignment 8, size 16.");
-define_vector!(Vec3, mint::Vector3<f32>, 16, f32, 3 <- "Vector of 3 f32s. Alignment 16, size 24.");
-define_vector!(Vec4, mint::Vector4<f32>, 16, f32, 4 <- "Vector of 4 f32s. Alignment 16, size 32.");
-define_vector!(DVec2, mint::Vector2<f64>, 16, f64, 2 <- "Vector of 2 f64s. Alignment 16, size 32.");
-define_vector!(DVec3, mint::Vector3<f64>, 32, f64, 3 <- "Vector of 3 f64s. Alignment 32, size 48.");
-define_vector!(DVec4, mint::Vector4<f64>, 32, f64, 4 <- "Vector of 4 f64s. Alignment 32, size 64.");
-define_vector!(UVec2, mint::Vector2<u32>, 8, u32, 2 <- "Vector of 2 u32s. Alignment 8, size 16.");
-define_vector!(UVec3, mint::Vector3<u32>, 16, u32, 3 <- "Vector of 3 u32s. Alignment 16, size 24.");
-define_vector!(UVec4, mint::Vector4<u32>, 16, u32, 4 <- "Vector of 4 u32s. Alignment 16, size 32.");
-define_vector!(IVec2, mint::Vector2<i32>, 8, i32, 2 <- "Vector of 2 i32s. Alignment 8, size 16.");
-define_vector!(IVec3, mint::Vector3<i32>, 16, i32, 3 <- "Vector of 3 i32s. Alignment 16, size 24.");
-define_vector!(IVec4, mint::Vector4<i32>, 16, i32, 4 <- "Vector of 4 i32s. Alignment 16, size 32.");
+define_vector!(Vec2, Vector2, 8, f32, 2 <- "Vector of 2 f32s. Alignment 8, size 16.");
+define_vector!(Vec3, Vector3, 16, f32, 3 <- "Vector of 3 f32s. Alignment 16, size 24.");
+define_vector!(Vec4, Vector4, 16, f32, 4 <- "Vector of 4 f32s. Alignment 16, size 32.");
+define_vector!(DVec2, Vector2, 16, f64, 2 <- "Vector of 2 f64s. Alignment 16, size 32.");
+define_vector!(DVec3, Vector3, 32, f64, 3 <- "Vector of 3 f64s. Alignment 32, size 48.");
+define_vector!(DVec4, Vector4, 32, f64, 4 <- "Vector of 4 f64s. Alignment 32, size 64.");
+define_vector!(UVec2, Vector2, 8, u32, 2 <- "Vector of 2 u32s. Alignment 8, size 16.");
+define_vector!(UVec3, Vector3, 16, u32, 3 <- "Vector of 3 u32s. Alignment 16, size 24.");
+define_vector!(UVec4, Vector4, 16, u32, 4 <- "Vector of 4 u32s. Alignment 16, size 32.");
+define_vector!(IVec2, Vector2, 8, i32, 2 <- "Vector of 2 i32s. Alignment 8, size 16.");
+define_vector!(IVec3, Vector3, 16, i32, 3 <- "Vector of 3 i32s. Alignment 16, size 24.");
+define_vector!(IVec4, Vector4, 16, i32, 4 <- "Vector of 4 i32s. Alignment 16, size 32.");
 
 macro_rules! define_matrix {
-    ($name:ident, $mint_type:ty, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal -> $($idx:literal),* <- $doc:literal) => {
+    ($name:ident, $mint_type:ident, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal -> $($idx:literal),* <- $doc:literal) => {
         #[doc = $doc]
         #[repr(C, align($align))]
         #[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
@@ -160,9 +160,9 @@ macro_rules! define_matrix {
         }
 
         #[cfg(feature = "mint")]
-        impl From<$mint_type> for $name {
+        impl From<mint::$mint_type<$inner_ty>> for $name {
             #[inline(always)]
-            fn from(other: $mint_type) -> Self {
+            fn from(other: mint::$mint_type<$inner_ty>) -> Self {
                 // Mint's types do not implement From for arrays, only Into.
                 let as_arr: [$inner_ty; $count_x * $count_y] = other.into();
                 as_arr.into()
@@ -198,7 +198,7 @@ macro_rules! define_matrix {
         }
 
         #[cfg(feature = "mint")]
-        impl From<$name> for $mint_type {
+        impl From<$name> for mint::$mint_type<$inner_ty> {
             #[inline(always)]
             fn from(other: $name) -> Self {
                 let as_arr = <[[$inner_ty; $count_x]; $count_y]>::from(other);
@@ -230,17 +230,17 @@ macro_rules! define_matrix {
     };
 }
 
-define_matrix!(Mat2x2, mint::ColumnMatrix2<f32>, 8, f32, Vec2, 2, 2, 0 -> 0, 1 <- "Matrix of f32s with 2 columns and 2 rows. Alignment 8, size 16.");
-define_matrix!(Mat2x3, mint::ColumnMatrix2x3<f32>, 8, f32, Vec2, 2, 3, 8 -> 0, 1, 2 <- "Matrix of f32s with 2 columns and 3 rows. Alignment 8, size 32.");
-define_matrix!(Mat2x4, mint::ColumnMatrix2x4<f32>, 8, f32, Vec2, 2, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f32s with 2 columns and 4 rows. Alignment 8, size 32.");
+define_matrix!(Mat2x2, ColumnMatrix2, 8, f32, Vec2, 2, 2, 0 -> 0, 1 <- "Matrix of f32s with 2 columns and 2 rows. Alignment 8, size 16.");
+define_matrix!(Mat2x3, ColumnMatrix2x3, 8, f32, Vec2, 2, 3, 8 -> 0, 1, 2 <- "Matrix of f32s with 2 columns and 3 rows. Alignment 8, size 32.");
+define_matrix!(Mat2x4, ColumnMatrix2x4, 8, f32, Vec2, 2, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f32s with 2 columns and 4 rows. Alignment 8, size 32.");
 
-define_matrix!(Mat3x2, mint::ColumnMatrix3x2<f32>, 16, f32, Vec3, 3, 2, 4 -> 0, 1 <- "Matrix of f32s with 3 columns and 2 rows. Alignment 16, size 32.");
-define_matrix!(Mat3x3, mint::ColumnMatrix3<f32>, 16, f32, Vec3, 3, 3, 4 -> 0, 1, 2 <- "Matrix of f32s with 3 columns and 3 rows. Alignment 16, size 48.");
-define_matrix!(Mat3x4, mint::ColumnMatrix3x4<f32>, 16, f32, Vec3, 3, 4, 4 -> 0, 1, 2, 3 <- "Matrix of f32s with 3 columns and 4 rows. Alignment 16, size 64.");
+define_matrix!(Mat3x2, ColumnMatrix3x2, 16, f32, Vec3, 3, 2, 4 -> 0, 1 <- "Matrix of f32s with 3 columns and 2 rows. Alignment 16, size 32.");
+define_matrix!(Mat3x3, ColumnMatrix3, 16, f32, Vec3, 3, 3, 4 -> 0, 1, 2 <- "Matrix of f32s with 3 columns and 3 rows. Alignment 16, size 48.");
+define_matrix!(Mat3x4, ColumnMatrix3x4, 16, f32, Vec3, 3, 4, 4 -> 0, 1, 2, 3 <- "Matrix of f32s with 3 columns and 4 rows. Alignment 16, size 64.");
 
-define_matrix!(Mat4x2, mint::ColumnMatrix4x2<f32>, 16, f32, Vec4, 4, 2, 0 -> 0, 1 <- "Matrix of f32s with 4 columns and 2 rows. Alignment 16, size 32.");
-define_matrix!(Mat4x3, mint::ColumnMatrix4x3<f32>, 16, f32, Vec4, 4, 3, 0 -> 0, 1, 2 <- "Matrix of f32s with 4 columns and 3 rows. Alignment 16, size 48.");
-define_matrix!(Mat4x4, mint::ColumnMatrix4<f32>, 16, f32, Vec4, 4, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f32s with 4 columns and 4 rows. Alignment 16, size 64.");
+define_matrix!(Mat4x2, ColumnMatrix4x2, 16, f32, Vec4, 4, 2, 0 -> 0, 1 <- "Matrix of f32s with 4 columns and 2 rows. Alignment 16, size 32.");
+define_matrix!(Mat4x3, ColumnMatrix4x3, 16, f32, Vec4, 4, 3, 0 -> 0, 1, 2 <- "Matrix of f32s with 4 columns and 3 rows. Alignment 16, size 48.");
+define_matrix!(Mat4x4, ColumnMatrix4, 16, f32, Vec4, 4, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f32s with 4 columns and 4 rows. Alignment 16, size 64.");
 
 /// Matrix of f32s with 2 columns and 2 rows. Alignment 8, size 16.
 pub type Mat2 = Mat2x2;
@@ -249,17 +249,17 @@ pub type Mat3 = Mat3x3;
 /// Matrix of f32s with 4 columns and 4 rows. Alignment 16, size 64.
 pub type Mat4 = Mat4x4;
 
-define_matrix!(DMat2x2, mint::ColumnMatrix2<f64>, 16, f64, DVec2, 2, 2, 0 -> 0, 1 <- "Matrix of f64s with 2 columns and 2 rows. Alignment 16, size 32.");
-define_matrix!(DMat2x3, mint::ColumnMatrix2x3<f64>, 16, f64, DVec2, 2, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 2 columns and 3 rows. Alignment 16, size 48.");
-define_matrix!(DMat2x4, mint::ColumnMatrix2x4<f64>, 16, f64, DVec2, 2, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 2 columns and 4 rows. Alignment 16, size 64.");
+define_matrix!(DMat2x2, ColumnMatrix2, 16, f64, DVec2, 2, 2, 0 -> 0, 1 <- "Matrix of f64s with 2 columns and 2 rows. Alignment 16, size 32.");
+define_matrix!(DMat2x3, ColumnMatrix2x3, 16, f64, DVec2, 2, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 2 columns and 3 rows. Alignment 16, size 48.");
+define_matrix!(DMat2x4, ColumnMatrix2x4, 16, f64, DVec2, 2, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 2 columns and 4 rows. Alignment 16, size 64.");
 
-define_matrix!(DMat3x2, mint::ColumnMatrix3x2<f64>, 32, f64, DVec3, 3, 2, 0 -> 0, 1 <- "Matrix of f64s with 3 columns and 2 rows. Alignment 32, size 64.");
-define_matrix!(DMat3x3, mint::ColumnMatrix3<f64>, 32, f64, DVec3, 3, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 3 columns and 3 rows. Alignment 32, size 96.");
-define_matrix!(DMat3x4, mint::ColumnMatrix3x4<f64>, 32, f64, DVec3, 3, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 3 columns and 4 rows. Alignment 32, size 128.");
+define_matrix!(DMat3x2, ColumnMatrix3x2, 32, f64, DVec3, 3, 2, 0 -> 0, 1 <- "Matrix of f64s with 3 columns and 2 rows. Alignment 32, size 64.");
+define_matrix!(DMat3x3, ColumnMatrix3, 32, f64, DVec3, 3, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 3 columns and 3 rows. Alignment 32, size 96.");
+define_matrix!(DMat3x4, ColumnMatrix3x4, 32, f64, DVec3, 3, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 3 columns and 4 rows. Alignment 32, size 128.");
 
-define_matrix!(DMat4x2, mint::ColumnMatrix4x2<f64>, 32, f64, DVec4, 4, 2, 0 -> 0, 1 <- "Matrix of f64s with 4 columns and 2 rows. Alignment 32, size 64.");
-define_matrix!(DMat4x3, mint::ColumnMatrix4x3<f64>, 32, f64, DVec4, 4, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 4 columns and 3 rows. Alignment 32, size 96.");
-define_matrix!(DMat4x4, mint::ColumnMatrix4<f64>, 32, f64, DVec4, 4, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 4 columns and 4 rows. Alignment 32, size 128.");
+define_matrix!(DMat4x2, ColumnMatrix4x2, 32, f64, DVec4, 4, 2, 0 -> 0, 1 <- "Matrix of f64s with 4 columns and 2 rows. Alignment 32, size 64.");
+define_matrix!(DMat4x3, ColumnMatrix4x3, 32, f64, DVec4, 4, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 4 columns and 3 rows. Alignment 32, size 96.");
+define_matrix!(DMat4x4, ColumnMatrix4, 32, f64, DVec4, 4, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 4 columns and 4 rows. Alignment 32, size 128.");
 
 /// Matrix of f64s with 2 columns and 3 rows. Alignment 16, size 48.
 pub type DMat2 = DMat2x2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ macro_rules! define_vector {
             }
         }
 
+        #[cfg(feature = "mint")]
         impl From<$mint_type> for $name {
             #[inline(always)]
             fn from(other: $mint_type) -> Self {
@@ -107,6 +108,7 @@ macro_rules! define_vector {
             }
         }
 
+        #[cfg(feature = "mint")]
         impl From<$name> for $mint_type {
             #[inline(always)]
             fn from(other: $name) -> Self {
@@ -162,6 +164,7 @@ macro_rules! define_matrix {
             }
         }
 
+        #[cfg(feature = "mint")]
         impl From<$mint_type> for $name {
             #[inline(always)]
             fn from(other: $mint_type) -> Self {
@@ -204,6 +207,7 @@ macro_rules! define_matrix {
             }
         }
 
+        #[cfg(feature = "mint")]
         impl From<$name> for $mint_type {
             #[inline(always)]
             fn from(other: $name) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ define_vector!(IVec3, mint::Vector3<i32>, 16, i32, 3 <- "Vector of 3 i32s. Align
 define_vector!(IVec4, mint::Vector4<i32>, 16, i32, 4 <- "Vector of 4 i32s. Alignment 16, size 32.");
 
 macro_rules! define_matrix {
-    ($name:ident, $mint_type:ty, [$($column:ident),*], $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal -> $($idx:literal),* <- $doc:literal) => {
+    ($name:ident, $mint_type:ty, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal -> $($idx:literal),* <- $doc:literal) => {
         #[doc = $doc]
         #[repr(C, align($align))]
         #[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
@@ -163,14 +163,9 @@ macro_rules! define_matrix {
         impl From<$mint_type> for $name {
             #[inline(always)]
             fn from(other: $mint_type) -> Self {
-                Self {
-                    inner: [
-                        $(
-                            other.$column.into(),
-                        )*
-                    ],
-                    _padding: [0; $padding],
-                }
+                // Mint's types do not implement From for arrays, only Into.
+                let as_arr: [$inner_ty; $count_x * $count_y] = other.into();
+                as_arr.into()
             }
         }
 
@@ -206,11 +201,8 @@ macro_rules! define_matrix {
         impl From<$name> for $mint_type {
             #[inline(always)]
             fn from(other: $name) -> Self {
-                Self {
-                    $(
-                        $column: other.inner[$idx].into(),
-                    )*
-                }
+                let as_arr = <[[$inner_ty; $count_x]; $count_y]>::from(other);
+                as_arr.into()
             }
         }
 
@@ -238,17 +230,17 @@ macro_rules! define_matrix {
     };
 }
 
-define_matrix!(Mat2x2, mint::ColumnMatrix2<f32>, [x, y], 8, f32, Vec2, 2, 2, 0 -> 0, 1 <- "Matrix of f32s with 2 columns and 2 rows. Alignment 8, size 16.");
-define_matrix!(Mat2x3, mint::ColumnMatrix2x3<f32>, [x, y, z], 8, f32, Vec2, 2, 3, 8 -> 0, 1, 2 <- "Matrix of f32s with 2 columns and 3 rows. Alignment 8, size 32.");
-define_matrix!(Mat2x4, mint::ColumnMatrix2x4<f32>, [x, y, z, w], 8, f32, Vec2, 2, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f32s with 2 columns and 4 rows. Alignment 8, size 32.");
+define_matrix!(Mat2x2, mint::ColumnMatrix2<f32>, 8, f32, Vec2, 2, 2, 0 -> 0, 1 <- "Matrix of f32s with 2 columns and 2 rows. Alignment 8, size 16.");
+define_matrix!(Mat2x3, mint::ColumnMatrix2x3<f32>, 8, f32, Vec2, 2, 3, 8 -> 0, 1, 2 <- "Matrix of f32s with 2 columns and 3 rows. Alignment 8, size 32.");
+define_matrix!(Mat2x4, mint::ColumnMatrix2x4<f32>, 8, f32, Vec2, 2, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f32s with 2 columns and 4 rows. Alignment 8, size 32.");
 
-define_matrix!(Mat3x2, mint::ColumnMatrix3x2<f32>, [x, y], 16, f32, Vec3, 3, 2, 4 -> 0, 1 <- "Matrix of f32s with 3 columns and 2 rows. Alignment 16, size 32.");
-define_matrix!(Mat3x3, mint::ColumnMatrix3<f32>, [x, y, z], 16, f32, Vec3, 3, 3, 4 -> 0, 1, 2 <- "Matrix of f32s with 3 columns and 3 rows. Alignment 16, size 48.");
-define_matrix!(Mat3x4, mint::ColumnMatrix3x4<f32>, [x, y, z, w], 16, f32, Vec3, 3, 4, 4 -> 0, 1, 2, 3 <- "Matrix of f32s with 3 columns and 4 rows. Alignment 16, size 64.");
+define_matrix!(Mat3x2, mint::ColumnMatrix3x2<f32>, 16, f32, Vec3, 3, 2, 4 -> 0, 1 <- "Matrix of f32s with 3 columns and 2 rows. Alignment 16, size 32.");
+define_matrix!(Mat3x3, mint::ColumnMatrix3<f32>, 16, f32, Vec3, 3, 3, 4 -> 0, 1, 2 <- "Matrix of f32s with 3 columns and 3 rows. Alignment 16, size 48.");
+define_matrix!(Mat3x4, mint::ColumnMatrix3x4<f32>, 16, f32, Vec3, 3, 4, 4 -> 0, 1, 2, 3 <- "Matrix of f32s with 3 columns and 4 rows. Alignment 16, size 64.");
 
-define_matrix!(Mat4x2, mint::ColumnMatrix4x2<f32>, [x, y], 16, f32, Vec4, 4, 2, 0 -> 0, 1 <- "Matrix of f32s with 4 columns and 2 rows. Alignment 16, size 32.");
-define_matrix!(Mat4x3, mint::ColumnMatrix4x3<f32>, [x, y, z], 16, f32, Vec4, 4, 3, 0 -> 0, 1, 2 <- "Matrix of f32s with 4 columns and 3 rows. Alignment 16, size 48.");
-define_matrix!(Mat4x4, mint::ColumnMatrix4<f32>, [x, y, z, w], 16, f32, Vec4, 4, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f32s with 4 columns and 4 rows. Alignment 16, size 64.");
+define_matrix!(Mat4x2, mint::ColumnMatrix4x2<f32>, 16, f32, Vec4, 4, 2, 0 -> 0, 1 <- "Matrix of f32s with 4 columns and 2 rows. Alignment 16, size 32.");
+define_matrix!(Mat4x3, mint::ColumnMatrix4x3<f32>, 16, f32, Vec4, 4, 3, 0 -> 0, 1, 2 <- "Matrix of f32s with 4 columns and 3 rows. Alignment 16, size 48.");
+define_matrix!(Mat4x4, mint::ColumnMatrix4<f32>, 16, f32, Vec4, 4, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f32s with 4 columns and 4 rows. Alignment 16, size 64.");
 
 /// Matrix of f32s with 2 columns and 2 rows. Alignment 8, size 16.
 pub type Mat2 = Mat2x2;
@@ -257,17 +249,17 @@ pub type Mat3 = Mat3x3;
 /// Matrix of f32s with 4 columns and 4 rows. Alignment 16, size 64.
 pub type Mat4 = Mat4x4;
 
-define_matrix!(DMat2x2, mint::ColumnMatrix2<f64>, [x, y], 16, f64, DVec2, 2, 2, 0 -> 0, 1 <- "Matrix of f64s with 2 columns and 2 rows. Alignment 16, size 32.");
-define_matrix!(DMat2x3, mint::ColumnMatrix2x3<f64>, [x, y, z], 16, f64, DVec2, 2, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 2 columns and 3 rows. Alignment 16, size 48.");
-define_matrix!(DMat2x4, mint::ColumnMatrix2x4<f64>, [x, y, z, w], 16, f64, DVec2, 2, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 2 columns and 4 rows. Alignment 16, size 64.");
+define_matrix!(DMat2x2, mint::ColumnMatrix2<f64>, 16, f64, DVec2, 2, 2, 0 -> 0, 1 <- "Matrix of f64s with 2 columns and 2 rows. Alignment 16, size 32.");
+define_matrix!(DMat2x3, mint::ColumnMatrix2x3<f64>, 16, f64, DVec2, 2, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 2 columns and 3 rows. Alignment 16, size 48.");
+define_matrix!(DMat2x4, mint::ColumnMatrix2x4<f64>, 16, f64, DVec2, 2, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 2 columns and 4 rows. Alignment 16, size 64.");
 
-define_matrix!(DMat3x2, mint::ColumnMatrix3x2<f64>, [x, y], 32, f64, DVec3, 3, 2, 0 -> 0, 1 <- "Matrix of f64s with 3 columns and 2 rows. Alignment 32, size 64.");
-define_matrix!(DMat3x3, mint::ColumnMatrix3<f64>, [x, y, z], 32, f64, DVec3, 3, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 3 columns and 3 rows. Alignment 32, size 96.");
-define_matrix!(DMat3x4, mint::ColumnMatrix3x4<f64>, [x, y, z, w], 32, f64, DVec3, 3, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 3 columns and 4 rows. Alignment 32, size 128.");
+define_matrix!(DMat3x2, mint::ColumnMatrix3x2<f64>, 32, f64, DVec3, 3, 2, 0 -> 0, 1 <- "Matrix of f64s with 3 columns and 2 rows. Alignment 32, size 64.");
+define_matrix!(DMat3x3, mint::ColumnMatrix3<f64>, 32, f64, DVec3, 3, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 3 columns and 3 rows. Alignment 32, size 96.");
+define_matrix!(DMat3x4, mint::ColumnMatrix3x4<f64>, 32, f64, DVec3, 3, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 3 columns and 4 rows. Alignment 32, size 128.");
 
-define_matrix!(DMat4x2, mint::ColumnMatrix4x2<f64>, [x, y], 32, f64, DVec4, 4, 2, 0 -> 0, 1 <- "Matrix of f64s with 4 columns and 2 rows. Alignment 32, size 64.");
-define_matrix!(DMat4x3, mint::ColumnMatrix4x3<f64>, [x, y, z], 32, f64, DVec4, 4, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 4 columns and 3 rows. Alignment 32, size 96.");
-define_matrix!(DMat4x4, mint::ColumnMatrix4<f64>, [x, y, z, w], 32, f64, DVec4, 4, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 4 columns and 4 rows. Alignment 32, size 128.");
+define_matrix!(DMat4x2, mint::ColumnMatrix4x2<f64>, 32, f64, DVec4, 4, 2, 0 -> 0, 1 <- "Matrix of f64s with 4 columns and 2 rows. Alignment 32, size 64.");
+define_matrix!(DMat4x3, mint::ColumnMatrix4x3<f64>, 32, f64, DVec4, 4, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 4 columns and 3 rows. Alignment 32, size 96.");
+define_matrix!(DMat4x4, mint::ColumnMatrix4<f64>, 32, f64, DVec4, 4, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 4 columns and 4 rows. Alignment 32, size 128.");
 
 /// Matrix of f64s with 2 columns and 3 rows. Alignment 16, size 48.
 pub type DMat2 = DMat2x2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 macro_rules! define_vector {
-    ($name:ident, [$($field:literal),*], $mint_type:ty, [$($mint_field:ident),*], $align:literal, $ty:ty, $count:literal<- $doc:literal) => {
+    ($name:ident, $mint_type:ty, $align:literal, $ty:ty, $count:literal<- $doc:literal) => {
         #[doc = $doc]
         #[repr(C, align($align))]
         #[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
@@ -91,11 +91,10 @@ macro_rules! define_vector {
         impl From<$mint_type> for $name {
             #[inline(always)]
             fn from(other: $mint_type) -> Self {
-                Self {
-                    inner: [
-                        $( other.$mint_field, )*
-                    ],
-                }
+                // Mint's types do not implement From for arrays, only Into.
+                let inner: [$ty; $count] = other.into();
+
+                Self { inner }
             }
         }
 
@@ -112,11 +111,7 @@ macro_rules! define_vector {
         impl From<$name> for $mint_type {
             #[inline(always)]
             fn from(other: $name) -> Self {
-                Self {
-                    $(
-                        $mint_field: other.inner[$field],
-                    )*
-                }
+                other.inner.into()
             }
         }
 
@@ -129,18 +124,18 @@ macro_rules! define_vector {
     };
 }
 
-define_vector!(Vec2, [0, 1], mint::Vector2<f32>, [x, y], 8, f32, 2 <- "Vector of 2 f32s. Alignment 8, size 16.");
-define_vector!(Vec3, [0, 1, 2], mint::Vector3<f32>, [x, y, z], 16, f32, 3 <- "Vector of 3 f32s. Alignment 16, size 24.");
-define_vector!(Vec4, [0, 1, 2, 3], mint::Vector4<f32>, [x, y, z, w], 16, f32, 4 <- "Vector of 4 f32s. Alignment 16, size 32.");
-define_vector!(DVec2, [0, 1], mint::Vector2<f64>, [x, y], 16, f64, 2 <- "Vector of 2 f64s. Alignment 16, size 32.");
-define_vector!(DVec3, [0, 1, 2], mint::Vector3<f64>, [x, y, z], 32, f64, 3 <- "Vector of 3 f64s. Alignment 32, size 48.");
-define_vector!(DVec4, [0, 1, 2, 3], mint::Vector4<f64>, [x, y, z, w], 32, f64, 4 <- "Vector of 4 f64s. Alignment 32, size 64.");
-define_vector!(UVec2, [0, 1], mint::Vector2<u32>, [x, y], 8, u32, 2 <- "Vector of 2 u32s. Alignment 8, size 16.");
-define_vector!(UVec3, [0, 1, 2], mint::Vector3<u32>, [x, y, z], 16, u32, 3 <- "Vector of 3 u32s. Alignment 16, size 24.");
-define_vector!(UVec4, [0, 1, 2, 3], mint::Vector4<u32>, [x, y, z, w], 16, u32, 4 <- "Vector of 4 u32s. Alignment 16, size 32.");
-define_vector!(IVec2, [0, 1], mint::Vector2<i32>, [x, y], 8, i32, 2 <- "Vector of 2 i32s. Alignment 8, size 16.");
-define_vector!(IVec3, [0, 1, 2], mint::Vector3<i32>, [x, y, z], 16, i32, 3 <- "Vector of 3 i32s. Alignment 16, size 24.");
-define_vector!(IVec4, [0, 1, 2, 3], mint::Vector4<i32>, [x, y, z, w], 16, i32, 4 <- "Vector of 4 i32s. Alignment 16, size 32.");
+define_vector!(Vec2, mint::Vector2<f32>, 8, f32, 2 <- "Vector of 2 f32s. Alignment 8, size 16.");
+define_vector!(Vec3, mint::Vector3<f32>, 16, f32, 3 <- "Vector of 3 f32s. Alignment 16, size 24.");
+define_vector!(Vec4, mint::Vector4<f32>, 16, f32, 4 <- "Vector of 4 f32s. Alignment 16, size 32.");
+define_vector!(DVec2, mint::Vector2<f64>, 16, f64, 2 <- "Vector of 2 f64s. Alignment 16, size 32.");
+define_vector!(DVec3, mint::Vector3<f64>, 32, f64, 3 <- "Vector of 3 f64s. Alignment 32, size 48.");
+define_vector!(DVec4, mint::Vector4<f64>, 32, f64, 4 <- "Vector of 4 f64s. Alignment 32, size 64.");
+define_vector!(UVec2, mint::Vector2<u32>, 8, u32, 2 <- "Vector of 2 u32s. Alignment 8, size 16.");
+define_vector!(UVec3, mint::Vector3<u32>, 16, u32, 3 <- "Vector of 3 u32s. Alignment 16, size 24.");
+define_vector!(UVec4, mint::Vector4<u32>, 16, u32, 4 <- "Vector of 4 u32s. Alignment 16, size 32.");
+define_vector!(IVec2, mint::Vector2<i32>, 8, i32, 2 <- "Vector of 2 i32s. Alignment 8, size 16.");
+define_vector!(IVec3, mint::Vector3<i32>, 16, i32, 3 <- "Vector of 3 i32s. Alignment 16, size 24.");
+define_vector!(IVec4, mint::Vector4<i32>, 16, i32, 4 <- "Vector of 4 i32s. Alignment 16, size 32.");
 
 macro_rules! define_matrix {
     ($name:ident, $mint_type:ty, [$($column:ident),*], $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal -> $($idx:literal),* <- $doc:literal) => {


### PR DESCRIPTION
Closes #1.

Mint is a library that defines common types for math libraries. By adding conversions from Mint types, shader-types gains the ability to convert from the types in most Rust math libraries with no additional work.