### PR TITLE
Introduce GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: ["*"]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust_version: [stable, "1.34.0"]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Rust toolchain
+      run: |
+        rustup default ${{ matrix.rust_version }}
+        rustup component add clippy rustfmt
+
+    - name: Build and test (default features)
+      run: |
+        cargo build --verbose
+        cargo test --verbose
+
+    - name: Build and test (all features)
+      run: |
+        cargo build --verbose --all-features
+        cargo test --verbose --all-features
+
+    - name: Build and test (no features)
+      run: |
+        cargo build --verbose --no-default-features
+        cargo test --verbose --no-default-features
+
+    - name: Rustfmt and Clippy
+      run: |
+        cargo fmt -- --check
+        cargo clippy
+      if: matrix.rust_version == 'stable'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,5 @@ jobs:
     - name: Rustfmt and Clippy
       run: |
         cargo fmt -- --check
-        cargo clippy
+        cargo clippy -- -D warnings
       if: matrix.rust_version == 'stable'


### PR DESCRIPTION
This PR introduces some basic CI using GitHub Actions. It runs on Rust stable and 1.34.0.

For each version, the workflow builds and tests separately. This can help catch build failures from accidentally depending on test-only code. The workflow builds with default features, all features, and with no features (to help catch any no-std regressions).