### PR TITLE
Add from_mint method for all types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,12 @@ macro_rules! define_vector {
                     inner,
                 }
             }
+
+            #[cfg(feature = "mint")]
+            #[inline(always)]
+            pub fn from_mint<T: Into<mint::$mint_type<$ty>>>(value: T) -> Self {
+                Self::from(value.into())
+            }
         }
 
         #[cfg(feature = "mint")]
@@ -156,6 +162,12 @@ macro_rules! define_matrix {
             #[inline(always)]
             pub fn new(inner: [$ty; $count_y]) -> Self {
                 Self { inner, _padding: [0; $padding] }
+            }
+
+            #[cfg(feature = "mint")]
+            #[inline(always)]
+            pub fn from_mint<T: Into<mint::$mint_type<$inner_ty>>>(value: T) -> Self {
+                Self::from(value.into())
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,8 @@ macro_rules! define_vector {
                 }
             }
 
+            /// Construct a vector from any type that can convert into the
+            /// equivalent mint vector type.
             #[cfg(feature = "mint")]
             #[inline(always)]
             pub fn from_mint<T: Into<mint::$mint_type<$ty>>>(value: T) -> Self {
@@ -164,6 +166,8 @@ macro_rules! define_matrix {
                 Self { inner, _padding: [0; $padding] }
             }
 
+            /// Construct a matrix from any type that can convert into the
+            /// equivalent mint matrix type.
             #[cfg(feature = "mint")]
             #[inline(always)]
             pub fn from_mint<T: Into<mint::$mint_type<$inner_ty>>>(value: T) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,8 +86,8 @@ macro_rules! define_vector {
                 }
             }
 
-            /// Construct a vector from any type that can convert into the
-            /// equivalent mint vector type.
+            /// Construct this vector from any type which is convertible into
+            /// the corresponding `mint` vector type.
             #[cfg(feature = "mint")]
             #[inline(always)]
             pub fn from_mint<T: Into<mint::$mint_type<$ty>>>(value: T) -> Self {
@@ -166,8 +166,8 @@ macro_rules! define_matrix {
                 Self { inner, _padding: [0; $padding] }
             }
 
-            /// Construct a matrix from any type that can convert into the
-            /// equivalent mint matrix type.
+            /// Construct this matrix from any type which is convertible into
+            /// the corresponding `mint` matrix type.
             #[cfg(feature = "mint")]
             #[inline(always)]
             pub fn from_mint<T: Into<mint::$mint_type<$inner_ty>>>(value: T) -> Self {


### PR DESCRIPTION
This helps resolve the requirement to use two `Into` conversions to go from math library types to shader-types types.

I was previously writing code like this:

```rust
let original = cgmath::Vector3::new(1.0, 2.0, 3.0);
let minty: mint::Vector3<f32> = original.into();
let shadery: shader_types::Vec3 = minty.into();
```

which can now just be:

```rust
let original = cgmath::Vector3::new(1.0, 2.0, 3.0);
let shadery = shader_types::Vec3::from_mint(original);
```