### PR TITLE
Clean up macros to be more readable and support better docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,26 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+macro_rules! define_vectors {
+    ( $(( $name:ident, $mint_name:ident, $prim:ident * $count:literal, align: $align:literal, size: $size:literal ),)* ) => {
+        $(
+            define_vector!(
+                $name,
+                mint::$mint_name<$prim>,
+                $align,
+                $prim,
+                $count,
+                concat!(
+                    "Vector of ", stringify!($count), " ", stringify!($prim), "s. ",
+                    "Alignment ", stringify!($align), " size ", stringify!($size), "."
+                )
+            );
+        )*
+    };
+}
+
 macro_rules! define_vector {
-    ($name:ident, $mint_type:ident, $align:literal, $ty:ty, $count:literal<- $doc:literal) => {
+    ($name:ident, $mint_type:ty, $align:literal, $ty:ty, $count:literal, $doc:expr) => {
         #[doc = $doc]
         #[repr(C, align($align))]
         #[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
@@ -90,15 +108,15 @@ macro_rules! define_vector {
             /// the corresponding `mint` vector type.
             #[cfg(feature = "mint")]
             #[inline(always)]
-            pub fn from_mint<T: Into<mint::$mint_type<$ty>>>(value: T) -> Self {
+            pub fn from_mint<T: Into<$mint_type>>(value: T) -> Self {
                 Self::from(value.into())
             }
         }
 
         #[cfg(feature = "mint")]
-        impl From<mint::$mint_type<$ty>> for $name {
+        impl From<$mint_type> for $name {
             #[inline(always)]
-            fn from(other: mint::$mint_type<$ty>) -> Self {
+            fn from(other: $mint_type) -> Self {
                 // Mint's types do not implement From for arrays, only Into.
                 let inner: [$ty; $count] = other.into();
 
@@ -116,7 +134,7 @@ macro_rules! define_vector {
         }
 
         #[cfg(feature = "mint")]
-        impl From<$name> for mint::$mint_type<$ty> {
+        impl From<$name> for $mint_type {
             #[inline(always)]
             fn from(other: $name) -> Self {
                 other.inner.into()
@@ -132,18 +150,20 @@ macro_rules! define_vector {
     };
 }
 
-define_vector!(Vec2, Vector2, 8, f32, 2 <- "Vector of 2 f32s. Alignment 8, size 16.");
-define_vector!(Vec3, Vector3, 16, f32, 3 <- "Vector of 3 f32s. Alignment 16, size 24.");
-define_vector!(Vec4, Vector4, 16, f32, 4 <- "Vector of 4 f32s. Alignment 16, size 32.");
-define_vector!(DVec2, Vector2, 16, f64, 2 <- "Vector of 2 f64s. Alignment 16, size 32.");
-define_vector!(DVec3, Vector3, 32, f64, 3 <- "Vector of 3 f64s. Alignment 32, size 48.");
-define_vector!(DVec4, Vector4, 32, f64, 4 <- "Vector of 4 f64s. Alignment 32, size 64.");
-define_vector!(UVec2, Vector2, 8, u32, 2 <- "Vector of 2 u32s. Alignment 8, size 16.");
-define_vector!(UVec3, Vector3, 16, u32, 3 <- "Vector of 3 u32s. Alignment 16, size 24.");
-define_vector!(UVec4, Vector4, 16, u32, 4 <- "Vector of 4 u32s. Alignment 16, size 32.");
-define_vector!(IVec2, Vector2, 8, i32, 2 <- "Vector of 2 i32s. Alignment 8, size 16.");
-define_vector!(IVec3, Vector3, 16, i32, 3 <- "Vector of 3 i32s. Alignment 16, size 24.");
-define_vector!(IVec4, Vector4, 16, i32, 4 <- "Vector of 4 i32s. Alignment 16, size 32.");
+define_vectors! {
+    (Vec2, Vector2, f32 * 2, align: 8, size: 16),
+    (Vec3, Vector3, f32 * 3, align: 16, size: 24),
+    (Vec4, Vector4, f32 * 4, align: 16, size: 32),
+    (DVec2, Vector2, f64 * 2, align: 16, size: 32),
+    (DVec3, Vector3, f64 * 3, align: 32, size: 48),
+    (DVec4, Vector4, f64 * 4, align: 32, size: 64),
+    (UVec2, Vector2, u32 * 2, align: 8, size: 16),
+    (UVec3, Vector3, u32 * 3, align: 16, size: 24),
+    (UVec4, Vector4, u32 * 4, align: 16, size: 32),
+    (IVec2, Vector2, i32 * 2, align: 8, size: 16),
+    (IVec3, Vector3, i32 * 3, align: 16, size: 24),
+    (IVec4, Vector4, i32 * 4, align: 16, size: 32),
+}
 
 macro_rules! define_matrix {
     ($name:ident, $mint_type:ident, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal -> $($idx:literal),* <- $doc:literal) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ macro_rules! define_vectors {
                     "Has size ", stringify!($size), " and alignment ", stringify!($align), "."
                 ),
                 concat!(
-                    "Construct a ", stringify!($name), " from any type which is convertable into a ",
+                    "Construct a `", stringify!($name), "` from any type which is convertable into a ",
                     "`mint::", stringify!($mint_name), "<", stringify!($prim), ">`."
                 )
             );
@@ -182,12 +182,16 @@ macro_rules! define_matrices {
                 concat!(
                     "Matrix of `", stringify!($prim_ty), "` with ", stringify!($rows), " rows and ", stringify!($cols), " columns. ",
                     "Has size ", stringify!($size), ", alignment ", stringify!($align), ", and ", stringify!($pad), " bytes of extra padding."
+                ),
+                concat!(
+                    "Construct a `", stringify!($name), "` from any type which is convertable into a ",
+                    "`mint::", stringify!($mint_name), "<", stringify!($prim_ty), ">`."
                 )
             );
         )*
     };
 
-    (@impl $name:ident, $mint_type:ty, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal, [$( $idx:literal ),*], $doc:expr) => {
+    (@impl $name:ident, $mint_type:ty, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal, [$( $idx:literal ),*], $doc:expr, $mint_doc:expr) => {
         #[doc = $doc]
         #[repr(C, align($align))]
         #[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
@@ -207,9 +211,8 @@ macro_rules! define_matrices {
                 Self { inner, _padding: [0; $padding] }
             }
 
-            /// Construct this matrix from any type which is convertible into
-            /// the corresponding `mint` matrix type.
             #[cfg(feature = "mint")]
+            #[doc = $mint_doc]
             #[inline(always)]
             pub fn from_mint<T: Into<$mint_type>>(value: T) -> Self {
                 Self::from(value.into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,23 +67,25 @@
 macro_rules! define_vectors {
     ( $(( $name:ident, $mint_name:ident, $prim:ident * $count:literal, align: $align:literal, size: $size:literal ),)* ) => {
         $(
-            define_vector!(
+            define_vectors!(@impl
                 $name,
                 mint::$mint_name<$prim>,
                 $align,
                 $prim,
                 $count,
                 concat!(
-                    "Vector of ", stringify!($count), " ", stringify!($prim), "s. ",
-                    "Alignment ", stringify!($align), " size ", stringify!($size), "."
+                    "Vector of ", stringify!($count), " `", stringify!($prim), "`. ",
+                    "Has size ", stringify!($size), " and alignment ", stringify!($align), "."
+                ),
+                concat!(
+                    "Construct a ", stringify!($name), " from any type which is convertable into a ",
+                    "`mint::", stringify!($mint_name), "<", stringify!($prim), ">`."
                 )
             );
         )*
     };
-}
 
-macro_rules! define_vector {
-    ($name:ident, $mint_type:ty, $align:literal, $ty:ty, $count:literal, $doc:expr) => {
+    (@impl $name:ident, $mint_type:ty, $align:literal, $ty:ty, $count:literal, $doc:expr, $mint_doc:expr) => {
         #[doc = $doc]
         #[repr(C, align($align))]
         #[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
@@ -104,9 +106,8 @@ macro_rules! define_vector {
                 }
             }
 
-            /// Construct this vector from any type which is convertible into
-            /// the corresponding `mint` vector type.
             #[cfg(feature = "mint")]
+            #[doc = $mint_doc]
             #[inline(always)]
             pub fn from_mint<T: Into<$mint_type>>(value: T) -> Self {
                 Self::from(value.into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ macro_rules! define_matrices {
                 [$( $idx ),*],
                 concat!(
                     "Matrix of `", stringify!($prim_ty), "` values with ", stringify!($rows), " rows and ", stringify!($cols), " columns. ",
-                    "Has size ", stringify!($size), ", alignment ", stringify!($align), ", and ", stringify!($pad), " bytes of extra padding."
+                    "Has size ", stringify!($size), " and alignment ", stringify!($align), "."
                 ),
                 concat!(
                     "Construct a `", stringify!($name), "` from any type which is convertable into a ",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,14 @@ define_vectors! {
     (IVec4, Vector4, i32 * 4, align: 16, size: 32),
 }
 
+macro_rules! define_matrices {
+    ( $(( $name:ident, $mint_name:ident, $prim_ty:ty, $row_ty:ty, $rows:literal * $cols:literal, align: $align:literal, size: $size:literal, pad: $pad:literal, [$($idx:literal),*] ),)* ) => {
+        $(
+            define_matrix!($name, $mint_name, $align, $prim_ty, $row_ty, $rows, $cols, $pad -> $( $idx ),* <- "hello");
+        )*
+    };
+}
+
 macro_rules! define_matrix {
     ($name:ident, $mint_type:ident, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal -> $($idx:literal),* <- $doc:literal) => {
         #[doc = $doc]
@@ -267,17 +275,31 @@ macro_rules! define_matrix {
     };
 }
 
-define_matrix!(Mat2x2, ColumnMatrix2, 8, f32, Vec2, 2, 2, 0 -> 0, 1 <- "Matrix of f32s with 2 columns and 2 rows. Alignment 8, size 16.");
-define_matrix!(Mat2x3, ColumnMatrix2x3, 8, f32, Vec2, 2, 3, 8 -> 0, 1, 2 <- "Matrix of f32s with 2 columns and 3 rows. Alignment 8, size 32.");
-define_matrix!(Mat2x4, ColumnMatrix2x4, 8, f32, Vec2, 2, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f32s with 2 columns and 4 rows. Alignment 8, size 32.");
+define_matrices! {
+    (Mat2x2, ColumnMatrix2, f32, Vec2, 2 * 2, align: 8, size: 0, pad: 0, [0, 1]),
+    (Mat2x3, ColumnMatrix2x3, f32, Vec2, 2 * 3, align: 8, size: 0, pad: 8, [0, 1, 2]),
+    (Mat2x4, ColumnMatrix2x4, f32, Vec2, 2 * 4, align: 8, size: 0, pad: 0, [0, 1, 2, 3]),
 
-define_matrix!(Mat3x2, ColumnMatrix3x2, 16, f32, Vec3, 3, 2, 4 -> 0, 1 <- "Matrix of f32s with 3 columns and 2 rows. Alignment 16, size 32.");
-define_matrix!(Mat3x3, ColumnMatrix3, 16, f32, Vec3, 3, 3, 4 -> 0, 1, 2 <- "Matrix of f32s with 3 columns and 3 rows. Alignment 16, size 48.");
-define_matrix!(Mat3x4, ColumnMatrix3x4, 16, f32, Vec3, 3, 4, 4 -> 0, 1, 2, 3 <- "Matrix of f32s with 3 columns and 4 rows. Alignment 16, size 64.");
+    (Mat3x2, ColumnMatrix3x2, f32, Vec3, 3 * 2, align: 16, size: 0, pad: 4, [0, 1]),
+    (Mat3x3, ColumnMatrix3, f32, Vec3, 3 * 3, align: 16, size: 0, pad: 4, [0, 1, 2]),
+    (Mat3x4, ColumnMatrix3x4, f32, Vec3, 3 * 4, align: 16, size: 0, pad: 4, [0, 1, 2, 3]),
 
-define_matrix!(Mat4x2, ColumnMatrix4x2, 16, f32, Vec4, 4, 2, 0 -> 0, 1 <- "Matrix of f32s with 4 columns and 2 rows. Alignment 16, size 32.");
-define_matrix!(Mat4x3, ColumnMatrix4x3, 16, f32, Vec4, 4, 3, 0 -> 0, 1, 2 <- "Matrix of f32s with 4 columns and 3 rows. Alignment 16, size 48.");
-define_matrix!(Mat4x4, ColumnMatrix4, 16, f32, Vec4, 4, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f32s with 4 columns and 4 rows. Alignment 16, size 64.");
+    (Mat4x2, ColumnMatrix4x2, f32, Vec4, 4 * 2, align: 16, size: 0, pad: 0, [0, 1]),
+    (Mat4x3, ColumnMatrix4x3, f32, Vec4, 4 * 3, align: 16, size: 0, pad: 0, [0, 1, 2]),
+    (Mat4x4, ColumnMatrix4, f32, Vec4, 4 * 4, align: 16, size: 0, pad: 0, [0, 1, 2, 3]),
+
+    (DMat2x2, ColumnMatrix2, f64, DVec2, 2 * 2, align: 16, size: 0, pad: 0, [0, 1]),
+    (DMat2x3, ColumnMatrix2x3, f64, DVec2, 2 * 3, align: 16, size: 0, pad: 0, [0, 1, 2]),
+    (DMat2x4, ColumnMatrix2x4, f64, DVec2, 2 * 4, align: 16, size: 0, pad: 0, [0, 1, 2, 3]),
+
+    (DMat3x2, ColumnMatrix3x2, f64, DVec3, 3 * 2, align: 32, size: 0, pad: 0, [0, 1]),
+    (DMat3x3, ColumnMatrix3, f64, DVec3, 3 * 3, align: 32, size: 0, pad: 0, [0, 1, 2]),
+    (DMat3x4, ColumnMatrix3x4, f64, DVec3, 3 * 4, align: 32, size: 0, pad: 0, [0, 1, 2, 3]),
+
+    (DMat4x2, ColumnMatrix4x2, f64, DVec4, 4 * 2, align: 32, size: 0, pad: 0, [0, 1]),
+    (DMat4x3, ColumnMatrix4x3, f64, DVec4, 4 * 3, align: 32, size: 0, pad: 0, [0, 1, 2]),
+    (DMat4x4, ColumnMatrix4, f64, DVec4, 4 * 4, align: 32, size: 0, pad: 0, [0, 1, 2, 3]),
+}
 
 /// Matrix of f32s with 2 columns and 2 rows. Alignment 8, size 16.
 pub type Mat2 = Mat2x2;
@@ -285,19 +307,6 @@ pub type Mat2 = Mat2x2;
 pub type Mat3 = Mat3x3;
 /// Matrix of f32s with 4 columns and 4 rows. Alignment 16, size 64.
 pub type Mat4 = Mat4x4;
-
-define_matrix!(DMat2x2, ColumnMatrix2, 16, f64, DVec2, 2, 2, 0 -> 0, 1 <- "Matrix of f64s with 2 columns and 2 rows. Alignment 16, size 32.");
-define_matrix!(DMat2x3, ColumnMatrix2x3, 16, f64, DVec2, 2, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 2 columns and 3 rows. Alignment 16, size 48.");
-define_matrix!(DMat2x4, ColumnMatrix2x4, 16, f64, DVec2, 2, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 2 columns and 4 rows. Alignment 16, size 64.");
-
-define_matrix!(DMat3x2, ColumnMatrix3x2, 32, f64, DVec3, 3, 2, 0 -> 0, 1 <- "Matrix of f64s with 3 columns and 2 rows. Alignment 32, size 64.");
-define_matrix!(DMat3x3, ColumnMatrix3, 32, f64, DVec3, 3, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 3 columns and 3 rows. Alignment 32, size 96.");
-define_matrix!(DMat3x4, ColumnMatrix3x4, 32, f64, DVec3, 3, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 3 columns and 4 rows. Alignment 32, size 128.");
-
-define_matrix!(DMat4x2, ColumnMatrix4x2, 32, f64, DVec4, 4, 2, 0 -> 0, 1 <- "Matrix of f64s with 4 columns and 2 rows. Alignment 32, size 64.");
-define_matrix!(DMat4x3, ColumnMatrix4x3, 32, f64, DVec4, 4, 3, 0 -> 0, 1, 2 <- "Matrix of f64s with 4 columns and 3 rows. Alignment 32, size 96.");
-define_matrix!(DMat4x4, ColumnMatrix4, 32, f64, DVec4, 4, 4, 0 -> 0, 1, 2, 3 <- "Matrix of f64s with 4 columns and 4 rows. Alignment 32, size 128.");
-
 /// Matrix of f64s with 2 columns and 3 rows. Alignment 16, size 48.
 pub type DMat2 = DMat2x2;
 /// Matrix of f64s with 3 columns and 3 rows. Alignment 32, size 96.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ define_vectors! {
 macro_rules! define_matrices {
     ( $(( $name:ident, $mint_name:ident, $prim_ty:ty, $row_ty:ty, $rows:literal * $cols:literal, align: $align:literal, size: $size:literal, pad: $pad:literal, [$($idx:literal),*] ),)* ) => {
         $(
-            define_matrix!(
+            define_matrices!(@impl
                 $name,
                 mint::$mint_name<$prim_ty>,
                 $align,
@@ -186,10 +186,8 @@ macro_rules! define_matrices {
             );
         )*
     };
-}
 
-macro_rules! define_matrix {
-    ($name:ident, $mint_type:ty, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal, [$( $idx:literal ),*], $doc:expr) => {
+    (@impl $name:ident, $mint_type:ty, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal, [$( $idx:literal ),*], $doc:expr) => {
         #[doc = $doc]
         #[repr(C, align($align))]
         #[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ macro_rules! define_vectors {
                 $prim,
                 $count,
                 concat!(
-                    "Vector of ", stringify!($count), " `", stringify!($prim), "`. ",
+                    "Vector of ", stringify!($count), " `", stringify!($prim), "` values. ",
                     "Has size ", stringify!($size), " and alignment ", stringify!($align), "."
                 ),
                 concat!(
@@ -180,7 +180,7 @@ macro_rules! define_matrices {
                 $pad,
                 [$( $idx ),*],
                 concat!(
-                    "Matrix of `", stringify!($prim_ty), "` with ", stringify!($rows), " rows and ", stringify!($cols), " columns. ",
+                    "Matrix of `", stringify!($prim_ty), "` values with ", stringify!($rows), " rows and ", stringify!($cols), " columns. ",
                     "Has size ", stringify!($size), ", alignment ", stringify!($align), ", and ", stringify!($pad), " bytes of extra padding."
                 ),
                 concat!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,13 +169,27 @@ define_vectors! {
 macro_rules! define_matrices {
     ( $(( $name:ident, $mint_name:ident, $prim_ty:ty, $row_ty:ty, $rows:literal * $cols:literal, align: $align:literal, size: $size:literal, pad: $pad:literal, [$($idx:literal),*] ),)* ) => {
         $(
-            define_matrix!($name, mint::$mint_name<$prim_ty>, $align, $prim_ty, $row_ty, $rows, $cols, $pad -> $( $idx ),* <- "hello");
+            define_matrix!(
+                $name,
+                mint::$mint_name<$prim_ty>,
+                $align,
+                $prim_ty,
+                $row_ty,
+                $rows,
+                $cols,
+                $pad,
+                [$( $idx ),*],
+                concat!(
+                    "Matrix of `", stringify!($prim_ty), "` with ", stringify!($rows), " rows and ", stringify!($cols), " columns. ",
+                    "Has size ", stringify!($size), ", alignment ", stringify!($align), ", and ", stringify!($pad), " bytes of extra padding."
+                )
+            );
         )*
     };
 }
 
 macro_rules! define_matrix {
-    ($name:ident, $mint_type:ty, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal -> $($idx:literal),* <- $doc:literal) => {
+    ($name:ident, $mint_type:ty, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal, [$( $idx:literal ),*], $doc:expr) => {
         #[doc = $doc]
         #[repr(C, align($align))]
         #[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
@@ -276,29 +290,29 @@ macro_rules! define_matrix {
 }
 
 define_matrices! {
-    (Mat2x2, ColumnMatrix2, f32, Vec2, 2 * 2, align: 8, size: 0, pad: 0, [0, 1]),
-    (Mat2x3, ColumnMatrix2x3, f32, Vec2, 2 * 3, align: 8, size: 0, pad: 8, [0, 1, 2]),
-    (Mat2x4, ColumnMatrix2x4, f32, Vec2, 2 * 4, align: 8, size: 0, pad: 0, [0, 1, 2, 3]),
+    (Mat2x2, ColumnMatrix2, f32, Vec2, 2 * 2, align: 8, size: 16, pad: 0, [0, 1]),
+    (Mat2x3, ColumnMatrix2x3, f32, Vec2, 2 * 3, align: 8, size: 32, pad: 8, [0, 1, 2]),
+    (Mat2x4, ColumnMatrix2x4, f32, Vec2, 2 * 4, align: 8, size: 32, pad: 0, [0, 1, 2, 3]),
 
-    (Mat3x2, ColumnMatrix3x2, f32, Vec3, 3 * 2, align: 16, size: 0, pad: 4, [0, 1]),
-    (Mat3x3, ColumnMatrix3, f32, Vec3, 3 * 3, align: 16, size: 0, pad: 4, [0, 1, 2]),
-    (Mat3x4, ColumnMatrix3x4, f32, Vec3, 3 * 4, align: 16, size: 0, pad: 4, [0, 1, 2, 3]),
+    (Mat3x2, ColumnMatrix3x2, f32, Vec3, 3 * 2, align: 16, size: 32, pad: 4, [0, 1]),
+    (Mat3x3, ColumnMatrix3, f32, Vec3, 3 * 3, align: 16, size: 48, pad: 4, [0, 1, 2]),
+    (Mat3x4, ColumnMatrix3x4, f32, Vec3, 3 * 4, align: 16, size: 64, pad: 4, [0, 1, 2, 3]),
 
-    (Mat4x2, ColumnMatrix4x2, f32, Vec4, 4 * 2, align: 16, size: 0, pad: 0, [0, 1]),
-    (Mat4x3, ColumnMatrix4x3, f32, Vec4, 4 * 3, align: 16, size: 0, pad: 0, [0, 1, 2]),
-    (Mat4x4, ColumnMatrix4, f32, Vec4, 4 * 4, align: 16, size: 0, pad: 0, [0, 1, 2, 3]),
+    (Mat4x2, ColumnMatrix4x2, f32, Vec4, 4 * 2, align: 16, size: 32, pad: 0, [0, 1]),
+    (Mat4x3, ColumnMatrix4x3, f32, Vec4, 4 * 3, align: 16, size: 48, pad: 0, [0, 1, 2]),
+    (Mat4x4, ColumnMatrix4, f32, Vec4, 4 * 4, align: 16, size: 64, pad: 0, [0, 1, 2, 3]),
 
-    (DMat2x2, ColumnMatrix2, f64, DVec2, 2 * 2, align: 16, size: 0, pad: 0, [0, 1]),
-    (DMat2x3, ColumnMatrix2x3, f64, DVec2, 2 * 3, align: 16, size: 0, pad: 0, [0, 1, 2]),
-    (DMat2x4, ColumnMatrix2x4, f64, DVec2, 2 * 4, align: 16, size: 0, pad: 0, [0, 1, 2, 3]),
+    (DMat2x2, ColumnMatrix2, f64, DVec2, 2 * 2, align: 16, size: 32, pad: 0, [0, 1]),
+    (DMat2x3, ColumnMatrix2x3, f64, DVec2, 2 * 3, align: 16, size: 48, pad: 0, [0, 1, 2]),
+    (DMat2x4, ColumnMatrix2x4, f64, DVec2, 2 * 4, align: 16, size: 64, pad: 0, [0, 1, 2, 3]),
 
-    (DMat3x2, ColumnMatrix3x2, f64, DVec3, 3 * 2, align: 32, size: 0, pad: 0, [0, 1]),
-    (DMat3x3, ColumnMatrix3, f64, DVec3, 3 * 3, align: 32, size: 0, pad: 0, [0, 1, 2]),
-    (DMat3x4, ColumnMatrix3x4, f64, DVec3, 3 * 4, align: 32, size: 0, pad: 0, [0, 1, 2, 3]),
+    (DMat3x2, ColumnMatrix3x2, f64, DVec3, 3 * 2, align: 32, size: 64, pad: 0, [0, 1]),
+    (DMat3x3, ColumnMatrix3, f64, DVec3, 3 * 3, align: 32, size: 96, pad: 0, [0, 1, 2]),
+    (DMat3x4, ColumnMatrix3x4, f64, DVec3, 3 * 4, align: 32, size: 128, pad: 0, [0, 1, 2, 3]),
 
-    (DMat4x2, ColumnMatrix4x2, f64, DVec4, 4 * 2, align: 32, size: 0, pad: 0, [0, 1]),
-    (DMat4x3, ColumnMatrix4x3, f64, DVec4, 4 * 3, align: 32, size: 0, pad: 0, [0, 1, 2]),
-    (DMat4x4, ColumnMatrix4, f64, DVec4, 4 * 4, align: 32, size: 0, pad: 0, [0, 1, 2, 3]),
+    (DMat4x2, ColumnMatrix4x2, f64, DVec4, 4 * 2, align: 32, size: 64, pad: 0, [0, 1]),
+    (DMat4x3, ColumnMatrix4x3, f64, DVec4, 4 * 3, align: 32, size: 96, pad: 0, [0, 1, 2]),
+    (DMat4x4, ColumnMatrix4, f64, DVec4, 4 * 4, align: 32, size: 128, pad: 0, [0, 1, 2, 3]),
 }
 
 /// Matrix of f32s with 2 columns and 2 rows. Alignment 8, size 16.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,13 +169,13 @@ define_vectors! {
 macro_rules! define_matrices {
     ( $(( $name:ident, $mint_name:ident, $prim_ty:ty, $row_ty:ty, $rows:literal * $cols:literal, align: $align:literal, size: $size:literal, pad: $pad:literal, [$($idx:literal),*] ),)* ) => {
         $(
-            define_matrix!($name, $mint_name, $align, $prim_ty, $row_ty, $rows, $cols, $pad -> $( $idx ),* <- "hello");
+            define_matrix!($name, mint::$mint_name<$prim_ty>, $align, $prim_ty, $row_ty, $rows, $cols, $pad -> $( $idx ),* <- "hello");
         )*
     };
 }
 
 macro_rules! define_matrix {
-    ($name:ident, $mint_type:ident, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal -> $($idx:literal),* <- $doc:literal) => {
+    ($name:ident, $mint_type:ty, $align:literal, $inner_ty:ty, $ty:ty, $count_x:literal, $count_y:literal, $padding:literal -> $($idx:literal),* <- $doc:literal) => {
         #[doc = $doc]
         #[repr(C, align($align))]
         #[derive(Debug, Copy, Clone, Default, PartialEq, PartialOrd)]
@@ -199,15 +199,15 @@ macro_rules! define_matrix {
             /// the corresponding `mint` matrix type.
             #[cfg(feature = "mint")]
             #[inline(always)]
-            pub fn from_mint<T: Into<mint::$mint_type<$inner_ty>>>(value: T) -> Self {
+            pub fn from_mint<T: Into<$mint_type>>(value: T) -> Self {
                 Self::from(value.into())
             }
         }
 
         #[cfg(feature = "mint")]
-        impl From<mint::$mint_type<$inner_ty>> for $name {
+        impl From<$mint_type> for $name {
             #[inline(always)]
-            fn from(other: mint::$mint_type<$inner_ty>) -> Self {
+            fn from(other: $mint_type) -> Self {
                 // Mint's types do not implement From for arrays, only Into.
                 let as_arr: [$inner_ty; $count_x * $count_y] = other.into();
                 as_arr.into()
@@ -243,7 +243,7 @@ macro_rules! define_matrix {
         }
 
         #[cfg(feature = "mint")]
-        impl From<$name> for mint::$mint_type<$inner_ty> {
+        impl From<$name> for $mint_type {
             #[inline(always)]
             fn from(other: $name) -> Self {
                 let as_arr = <[[$inner_ty; $count_x]; $count_y]>::from(other);


### PR DESCRIPTION
Early work in progress. This might not be worth pursuing in its current form and I wasn't able to finish it in one sitting, so I'm sticking it here for feedback now.

This PR changes the vector macros in a couple ways:
- Merged all vectors into one recursive macro call
- Changed docs to be generated based on inputs
- Reduced number of `mint::$mint_ty<$ty>`-ish repetitions
- Normalized formatting of macro inputs, then spruced them back up a bit

The documentation stuff is pretty gnarly. One nice property is that we can guarantee the docs are correct though, since the information is no longer duplicated and can have additional tests applied to it! 😅

Things to definitely do before merging:
- [x] Apply to matrices as well
- [x] Docs for mint matrix stuff